### PR TITLE
chore(workflows): add "CI / Lint (cargo clippy)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,21 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+
+  lint_cargo_clippy:
+    name: Lint (cargo clippy)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+
+      - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: clippy
+
+      - uses: actions-rs/clippy-check@b5b5f21f4797c02da247df37026fcd0a5024aa4d
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features

--- a/example/example/src/main.rs
+++ b/example/example/src/main.rs
@@ -1,3 +1,6 @@
 fn main() {
-    println!("Hello, world!");
+    let name = "hello";
+    if name.chars().next() == Some('h') {
+        println!("Hello, world!");
+    };
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Add `CI / Lint (cargo clippy)` for this repo, see https://github.com/actions-rs/clippy-check

> This GitHub Action executes [clippy](https://github.com/rust-lang/rust-clippy) and posts all lints as annotations for the pushed commit, as in the live example [here](https://github.com/actions-rs/example/pull/2/files).
