### PR TITLE
chore(governance): clean up health files and auto labeling

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,15 +1,5 @@
 # Define individuals that are responsible for code in this repository.
 # More details are here: https://help.github.com/articles/about-codeowners/
 
-/.github/                                       @fuxingloh
-/.github/workflows                              @fuxingloh @surangap
-/.idea/                                         @fuxingloh
-
-/docs/                                          @surangap @fuxingloh @DieHard073055 @canonbrother
-/meta/                                          @surangap @fuxingloh @DieHard073055 @canonbrother
-
 README.md                                       @fuxingloh
 LICENSE                                         @fuxingloh
-rustfmt.toml                                    @surangap @fuxingloh
-Cargo.toml                                      @surangap @fuxingloh
-Cargo.lock                                      @surangap @fuxingloh

--- a/.github/governance.yml
+++ b/.github/governance.yml
@@ -37,6 +37,11 @@ issue:
       list:
         - workflow
         - docs
+        - meta-consensus
+        - meta-node
+        - meta-runtime
+        - testcontainers
+        - e2e-testing
       multiple: true
       needs:
         comment: |

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -36,10 +36,35 @@ labels:
     matcher:
       files: ".github/**"
 
+  - label: area/meta-consensus
+    sync: true
+    matcher:
+      files: "meta/meta-consensus/**"
+
+  - label: area/meta-node
+    sync: true
+    matcher:
+      files: "meta/meta-node/**"
+
+  - label: area/meta-runtime
+    sync: true
+    matcher:
+      files: "meta/meta-runtime/**"
+
   - label: area/docs
     sync: true
     matcher:
-      files: "docs/**"
+      files: "packages/docs/**"
+
+  - label: area/testcontainers
+    sync: true
+    matcher:
+      files: "packages/testcontainers/**"
+
+  - label: area/e2e-testing
+    sync: true
+    matcher:
+      files: "packages/e2e-testing/**"
 
 checks:
   - context: "Semantic Pull Request"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -54,6 +54,16 @@
   name: area/workflow
 - color: fbca04
   name: area/docs
+- color: fbca04
+  name: area/meta-consensus
+- color: fbca04
+  name: area/meta-node
+- color: fbca04
+  name: area/meta-runtime
+- color: fbca04
+  name: area/testcontainers
+- color: fbca04
+  name: area/e2e-testing
 
 # Priority
 - color: d93f0b


### PR DESCRIPTION
#### What this PR does / why we need it:

As per the title. Also, removes CODEOWNERS for now since we're cleaning up and refactoring the repo. The label automation affects release draft publishing as it picks up area of concerns to place change into their contextual sections.
