### PR TITLE
chore(packages): add network and typescript package

### DIFF
--- a/packages/network/README.md
+++ b/packages/network/README.md
@@ -1,0 +1,7 @@
+---
+title: Network
+---
+
+`@defimetachain/network`
+
+DeFi Meta Chain various network configurations for MainNet, TestNet, and other testing purposes.

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@defimetachain/network",
+  "version": "0.0.0",
+  "main": "./dist/index.js",
+  "source": "./src/index.ts",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist/**"
+  ],
+  "scripts": {
+    "build": "tsc -b ./tsconfig.build.json",
+    "clean": "rm -rf dist",
+    "lint": "eslint src"
+  },
+  "eslintConfig": {
+    "parserOptions": {
+      "project": "./tsconfig.json"
+    },
+    "extends": [
+      "@birthdayresearch"
+    ]
+  },
+  "devDependencies": {
+    "@defimetachain/typescript": "workspace:*"
+  }
+}

--- a/packages/network/src/index.ts
+++ b/packages/network/src/index.ts
@@ -1,0 +1,1 @@
+export const ChainId: number = 988;

--- a/packages/network/tsconfig.build.json
+++ b/packages/network/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/*.unit.ts"]
+}

--- a/packages/network/tsconfig.json
+++ b/packages/network/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@defimetachain/typescript/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src"]
+}

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -1,0 +1,7 @@
+---
+title: Typescript
+---
+
+`@defimetachain/typescript` 
+
+For housing and keeping `tsconfig.json` DRY.

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@defimetachain/typescript",
+  "private": true,
+  "version": "0.0.0",
+  "files": [
+    "tsconfig.json"
+  ],
+  "dependencies": {
+    "typescript": "4.7.4"
+  }
+}

--- a/packages/typescript/tsconfig.json
+++ b/packages/typescript/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Default",
+  "compilerOptions": {
+    "lib": ["ES2020"],
+    "module": "CommonJS",
+    "target": "ES2022",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "composite": false,
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": false,
+    "isolatedModules": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "preserveWatchOutput": true
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,18 @@ importers:
     devDependencies:
       '@birthdayresearch/contented': 1.6.0_typanion@3.9.0
 
+  packages/network:
+    specifiers:
+      '@defimetachain/typescript': workspace:*
+    devDependencies:
+      '@defimetachain/typescript': link:../typescript
+
+  packages/typescript:
+    specifiers:
+      typescript: 4.7.4
+    dependencies:
+      typescript: 4.7.4
+
 packages:
 
   /@babel/generator/7.19.0:
@@ -3032,7 +3044,6 @@ packages:
     resolution: {integrity: sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==}
     engines: {node: '>=4.2.0'}
     hasBin: true
-    dev: true
 
   /typescript/4.8.2:
     resolution: {integrity: sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==}


### PR DESCRIPTION
#### What this PR does / why we need it:

Add internal `@defimetachain/typescript` for housing and keeping `tsconfig.json` DRY and public `@defimetachain/network` for various network configurations for MainNet, TestNet, and other testing purposes.
